### PR TITLE
Multiple Go Files + vscode settings in root folder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "go.gopath": "${workspaceFolder}\\gopath",
+    "go.goroot": "${workspaceFolder}\\go",
+    "go.lintOnSave": "file"
+}

--- a/App/build.bat
+++ b/App/build.bat
@@ -1,2 +1,2 @@
 SET GOPATH=%CD%\..\gopath
-..\go\bin\go.exe build -o app.exe main.go pkged.go
+..\go\bin\go.exe build -o app.exe main.go helpers.go pkged.go

--- a/App/helpers.go
+++ b/App/helpers.go
@@ -1,0 +1,5 @@
+package main
+
+func testHelper() (string) {
+	return "Hello, World!"
+}

--- a/App/helpers.go
+++ b/App/helpers.go
@@ -1,5 +1,23 @@
 package main
 
-func testHelper() (string) {
-	return "Hello, World!"
+import (
+	"io"
+	"strings"
+
+	"github.com/markbates/pkger/pkging"
+)
+
+func panicOnErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func getStringFromFile(file pkging.File, err error) string {
+	panicOnErr(err)
+	buf := new(strings.Builder)
+	n, err := io.Copy(buf, file)
+	_ = n
+	panicOnErr(err)
+	return buf.String()
 }

--- a/App/main.go
+++ b/App/main.go
@@ -53,6 +53,7 @@ func main() {
 	settings := getSettings()
 
 	fmt.Println(settings)
+	fmt.Println(testHelper())
 
 	r := gin.Default()
 

--- a/App/main.go
+++ b/App/main.go
@@ -2,20 +2,12 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/markbates/pkger"
 )
-
-func panicOnErr(err error) {
-	if err != nil {
-		panic(err)
-	}
-}
 
 func getExecutable() string {
 	ex, err := os.Executable()
@@ -40,12 +32,7 @@ func portableExe() {
 // TODO: return a Settings struct
 func getSettings() string {
 	file, err := pkger.Open("/data/settings.json")
-	panicOnErr(err)
-	buf := new(strings.Builder)
-	n, err := io.Copy(buf, file)
-	_ = n
-	panicOnErr(err)
-	return buf.String()
+	return getStringFromFile(file, err)
 }
 
 func main() {
@@ -53,7 +40,6 @@ func main() {
 	settings := getSettings()
 
 	fmt.Println(settings)
-	fmt.Println(testHelper())
 
 	r := gin.Default()
 

--- a/App/run.bat
+++ b/App/run.bat
@@ -1,3 +1,3 @@
 SET GOPATH=%CD%\..\gopath
-..\go\bin\go.exe build -o app.exe main.go pkged.go
+..\go\bin\go.exe build -o app.exe main.go helpers.go pkged.go
 app.exe


### PR DESCRIPTION
Learning how to write multiple files.
In Go, you don't need to include files from the same package

helpers.go added. This is where basic functions needed by most files should go. This paradigm isn't needed in go but is still cleaner to read.

Added vscode settings to the root folder.